### PR TITLE
Tuning tuorial

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -12,9 +12,10 @@ class ProfilesController < ApplicationController
   private
 
   def user_safe?
-    @user.user_cautions.all? do |user_caution|
-      Time.zone.now > user_caution.caution_freeze.end_time
-    end
+    # INNER JOIN句を使用する為、joinsメソッドを使用
+    # LEFT OUTER JOINを使用した場合、caution_freezesが存在しないuser_cautionsを取得してしまい余計なデータを処理対象にしてしまい処理コストが増える
+    @user.user_cautions.joins(:caution_freeze).
+    where("caution_freezes.end_time > ?", Time.zone.now).blank?
   end
 
   def user_reccomend_skill_categories

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -18,7 +18,8 @@ class ProfilesController < ApplicationController
   end
 
   def user_reccomend_skill_categories
-    @user.skills.map(&:skill_category).
-      filter { |skill_category| skill_category.reccomend }.uniq
+    SkillCategory.eager_load(:skills).
+    where(reccomend: true).
+    where(skills: { user_id: @user.id })
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -4,7 +4,9 @@ class ProfilesController < ApplicationController
     raise Forbidden unless user_safe?
 
     @skill_categories = user_reccomend_skill_categories
-    @articles = @user.articles
+    # ユーザーに紐づく記事をすべて取得
+    # 関連テーブルでの絞り込みがないため、LEFT OUTER JOIN句を使わないpreloadを使用
+    @articles = @user.articles.preload(:tags)
   end
 
   private

--- a/app/views/profiles/_articles.html.erb
+++ b/app/views/profiles/_articles.html.erb
@@ -14,6 +14,7 @@
               <%= article.title %>
             </h3>
             <p><%= article.description %></p>
+          <%# 取得した記事毎に、記事に紐づくすべてのタグ名を表示 %>
             <% article.tags.each do |tag| %>
               <span class="tag is-light"><%= tag.name %></span>
             <% end %>


### PR DESCRIPTION
### eager_loadでネストした関連モデルのデータを一括取得
```ruby
User.eager_load(user_cautions: :caution_freeze).where(caution_freezes: { id: 1 })
```

includesメソッドでは以下の条件に合致する場合にはeager_loadの挙動を、合致しない場合はpreloadの挙動を行います。

- 引数に指定した関連テーブルに対しjoinsメソッドを使用している場合
- 引数に指定した関連テーブルに対しwhereメソッドを使用している場合
- 引数に指定した関連テーブルに対しreferencesメソッドを使用している場合

### includesメソッドの注意点

状況に応じてよしなに挙動を変えてくれるincludesメソッドは便利だと思います。
ですが筆者はincludesメソッドの使用は推奨しません。
なぜなら、後で未来の自分や他の人がコードリーディングする時、特にパフォーマンスチューニングをする時に、そのコードを書いた時点で自分がeager_loadかpreloadのどちらを狙ってincludesを使用したのか意図がわからなくなる為です。
もし、意図が読み解けたとしても、読み解く事に掛ける時間がもったいないので、コードを書いた時点でその時の意図が分かるようにincludesではなくeager_loadかpreloadを使用する事を推奨します。